### PR TITLE
Add minimum rectangle width

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -278,14 +278,22 @@ impl<'a> DrawingBackend for SVGBackend<'a> {
         } else {
             (make_svg_color(style.color()), "none".to_string())
         };
+        let mut width = bottom_right.0 - upper_left.0;
+        if width <= 0 {
+            width = 1;
+        };
+        let mut height = bottom_right.1 - upper_left.1;
+        if height <= 0 {
+            height = 1;
+        };
 
         self.open_tag(
             SVGTag::Rectangle,
             &[
                 ("x", &format!("{}", upper_left.0)),
                 ("y", &format!("{}", upper_left.1)),
-                ("width", &format!("{}", bottom_right.0 - upper_left.0)),
-                ("height", &format!("{}", bottom_right.1 - upper_left.1)),
+                ("width", &format!("{}", width)),
+                ("height", &format!("{}", height)),
                 ("opacity", &make_svg_opacity(style.color())),
                 ("fill", &fill),
                 ("stroke", &stroke),


### PR DESCRIPTION
If the canvas is not sufficiently proportioned, the svg value written as width can become negative and the rectangles disappear.
This is initially confusing. Adding a catch for such cases ensures that a best effort is made to still render something.
Arguably this check could be done in `plotters`.