### PR TITLE
Proposal to use git-master dependencies for collaboration, testing, and CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,17 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-plotters-backend = "^0.3.*"
+[dependencies.plotters-backend]
+branch = "master"
+git = "https://github.com/plotters-rs/plotters-backend"
+# version = "0.3.1"
 
 [features]
 debug = []
 
-[dev-dependencies]
-plotters = {version = "^0.3.0", default_features = false, features = ["ttf"]}
+[dev-dependencies.plotters]
+branch = "master"
+default_features = false
+features = ["ttf"]
+git = "https://github.com/plotters-rs/plotters"
+# version = "0.3.1"


### PR DESCRIPTION
This proposal aims to improve collaboration, testing, and CI by altering the version of the `plotters-backend` and `plotters` dependencies in `Cargo.toml`. Instead of using the stable versions of those crates, the `git-master` versions are used.

Using the `git-master` versions of the `plotters-` crates is vital for pre-release quality assurance and frustration-free collaboration in Plotters. It also reduces surprises at release time.

This is part of the proposal discussed on plotters-rs/plotters#373